### PR TITLE
improvement: add realworld use case benchmarks

### DIFF
--- a/benchmarks/index.ts
+++ b/benchmarks/index.ts
@@ -1,0 +1,26 @@
+import { Suite } from 'benchmark'
+const suite = new Suite()
+
+import { Env } from '../src/Env'
+const cachedInstance = new Env(true)
+const nonCachedInstance = new Env()
+
+cachedInstance.process('APP_KEY = 10')
+nonCachedInstance.process('APP_KEY = 10')
+
+// add tests
+suite
+  .add('With Cache', function () {
+    cachedInstance.get('APP_KEY')
+  })
+  .add('Without Cache', function () {
+    nonCachedInstance.get('APP_KEY')
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
+  // run async
+  .run()

--- a/package-lock.json
+++ b/package-lock.json
@@ -964,6 +964,16 @@
         }
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "boundary": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
@@ -5652,6 +5662,12 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
     },
     "please-upgrade-node": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@poppinss/dev-utils": "^1.0.6",
     "@types/dotenv": "^8.2.0",
     "@types/node": "^14.0.1",
+    "benchmark": "^2.1.4",
     "commitizen": "^4.1.2",
     "cz-conventional-changelog": "^3.2.0",
     "del-cli": "^3.0.0",

--- a/src/Env.ts
+++ b/src/Env.ts
@@ -20,6 +20,9 @@ import { EnvContract } from '@ioc:Adonis/Core/Env'
  * AdonisJs automatically reads and passes the contents of `.env` file to this class.
  */
 export class Env implements EnvContract {
+  constructor (private cache: boolean = false) {
+  }
+
   /**
    *  Cached value of any environement variables to avoid
    *  multiple call to `process.env`.
@@ -194,7 +197,7 @@ export class Env implements EnvContract {
       if (process.env[key] === undefined || overwrite) {
         const interpolatedValue = this.interpolate(envCollection[key], envCollection)
         process.env[key] = interpolatedValue
-        this.cachedValue.set(key, this.castValue(interpolatedValue))
+        this.cache && this.cachedValue.set(key, this.castValue(interpolatedValue))
       }
     })
   }
@@ -222,7 +225,7 @@ export class Env implements EnvContract {
    * ```
    */
   public get (key: string, defaultValue?: any): string | boolean | null | undefined {
-    if (this.cachedValue.has(key)) {
+    if (this.cache && this.cachedValue.has(key)) {
       return this.cachedValue.get(key) as string | boolean | null | undefined
     }
 
@@ -276,8 +279,7 @@ export class Env implements EnvContract {
    */
   public set (key: string, value: string): void {
     const interpolatedValue = this.interpolate(value, {})
-
-    this.cachedValue.set(key, this.castValue(interpolatedValue))
+    this.cache && this.cachedValue.set(key, this.castValue(interpolatedValue))
     process.env[key] = interpolatedValue
   }
 }


### PR DESCRIPTION
Every test creates a new instance of Env and hence cache has literally no impact. I have created  proper benchmarks using a single shared instance (that is how the real app will work) and the gains of caching are tremendous. 

```
With Cache x 96,787,914 ops/sec ±0.29% (95 runs sampled)
Without Cache x 2,509,525 ops/sec ±0.69% (92 runs sampled)
Fastest is With Cache
```