### PR TITLE
feat(env): add support for more than .env.testing alternate environments

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -41,11 +41,15 @@ export function envLoader (appRoot: string): { envContents: string, testEnvConte
   const envContents = loadFile(absPath, process.env.ENV_SILENT === 'true')
 
   /**
-   * Optionally loading the `.env.testing` file in test environment
+   * Optionally load an alternate environment 
+   * .env.testing or .env.development (or any other) for example,
+   * if specified by NODE_ENV
    */
   let testEnvContent = ''
-  if (process.env.NODE_ENV === 'testing') {
-    testEnvContent = loadFile(join(appRoot, '.env.testing'), true)
+  let envFile = ''
+  if (process.env.NODE_ENV !== undefined && process.env.NODE_ENV !== '') {
+    envFile = '.env.' + process.env.NODE_ENV
+    testEnvContent = loadFile(join(appRoot, envFile), true)
   }
 
   return { testEnvContent, envContents }

--- a/test/loader.spec.ts
+++ b/test/loader.spec.ts
@@ -88,4 +88,15 @@ test.group('Env loader', (group) => {
 
     delete process.env.NODE_ENV
   })
+
+  test('load .env when exists and .env.development does not and NODE_ENV=development', async (assert) => {
+    process.env.NODE_ENV = 'development'
+    await fs.add('.env', 'PORT=3000')
+
+    const { envContents, testEnvContent } = envLoader(fs.basePath)
+    assert.equal(envContents, 'PORT=3000')
+    assert.equal(testEnvContent, '')
+
+    delete process.env.NODE_ENV
+  })
 })

--- a/test/loader.spec.ts
+++ b/test/loader.spec.ts
@@ -52,4 +52,40 @@ test.group('Env loader', (group) => {
     assert.equal(envContents, 'PORT=3000')
     assert.equal(testEnvContent, '')
   })
+
+  test('load alternate .env.development when exists and NODE_ENV = development', async (assert) => {
+    process.env.NODE_ENV = 'development'
+
+    await fs.add('.env', 'PORT=3000')
+    await fs.add('.env.development', 'PORT=5000')
+
+    const { envContents, testEnvContent } = envLoader(fs.basePath)
+    assert.equal(envContents, 'PORT=3000')
+    assert.equal(testEnvContent, 'PORT=5000')
+
+    delete process.env.NODE_ENV
+  })
+
+  test('do not load .env.development when exists and NODE_ENV != development', async (assert) => {
+    await fs.add('.env', 'PORT=3000')
+    await fs.add('.env.development', 'PORT=5000')
+
+    const { envContents, testEnvContent } = envLoader(fs.basePath)
+    assert.equal(envContents, 'PORT=3000')
+    assert.equal(testEnvContent, '')
+
+    delete process.env.NODE_ENV
+  })
+
+  test('do not load alternate .env.development when NODE_ENV = undefined', async (assert) => {
+    process.env.NODE_ENV = undefined
+    await fs.add('.env', 'PORT=3000')
+    await fs.add('.env.development', 'PORT=5000')
+
+    const { envContents, testEnvContent } = envLoader(fs.basePath)
+    assert.equal(envContents, 'PORT=3000')
+    assert.equal(testEnvContent, '')
+
+    delete process.env.NODE_ENV
+  })
 })


### PR DESCRIPTION
## Proposed changes

Following up with my forum post, https://forum.adonisjs.com/t/more-env-files-other-than-env-testing/6562 it seems that adonisjs only supports one alternative .env file called `.env.testing`. It would seem to me like an easy addition to add support for more `.env` files based on `NODE_ENV` environment variable. (I needed 3 for my Adonis and Nuxtjs project)

## Types of changes

I have made a small change (less than 5 LOC not including tests) which loads an alternate `.env` based on `NODE_ENV`. For example, if `NODE_ENV=development`, then a `.env.development` will be loaded and merged. If `NODE_ENV=foobar` then a `.env.foobar` will be loaded if it exists, etc. Of course, `.env.testing` still works as well.

I have also written 3 tests (an additional 6-9ms of testing time) that test my added functionality.

## What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/env/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

Note: If accepted, I will be happy to add the relevant documentation.

## Further comments

While I have 4+ years in Javascript development and 5+ in Python, this is my first formal pull request, and I will not be offended if I need to change anything to improve my addition or if it goes against any principles and gets rejected.

I love Adonisjs and I hope to see it continue to prosper!

Thanks!
Ryan
