### PR TITLE
chore: remove types/dotenv

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 13th 2020, 9:48:29 am
+                            October 14th 2020, 11:47:27 am
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 		"@adonisjs/mrm-preset": "^2.4.0",
 		"@adonisjs/require-ts": "^1.0.0",
 		"@poppinss/dev-utils": "^1.0.11",
-		"@types/dotenv": "^8.2.0",
 		"@types/node": "^14.11.8",
 		"commitizen": "^4.2.1",
 		"cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
The dotenv library now includes its types.

```
npm WARN deprecated @types/dotenv@8.2.0: This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.
```