### PR TITLE
feat: allow to configure strictness of url validator

### DIFF
--- a/adonis-typings/env.ts
+++ b/adonis-typings/env.ts
@@ -28,12 +28,28 @@ declare module '@ioc:Adonis/Core/Env' {
 		message?: string
 	}
 
+	export type StringFnUrlOptions = SchemaFnOptions & {
+		format: 'url'
+		/**
+		 * Whether the URL must have a valid TLD in their domain.
+		 * Defaults to `true`.
+		 */
+		tld?: boolean
+		/**
+		 * Whether the URL must start with a valid protocol.
+		 * Defaults to `true`.
+		 */
+		protocol?: boolean
+	}
+
 	/**
 	 * Options accepted by the string schema function
 	 */
-	export type StringFnOptions = SchemaFnOptions & {
-		format?: 'host' | 'email' | 'url'
-	}
+	export type StringFnOptions =
+		| (SchemaFnOptions & {
+				format?: 'host' | 'email'
+		  })
+		| StringFnUrlOptions
 
 	/**
 	 * Shape of the number validator

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -47,7 +47,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            12
+                            0
                         </h5>
                         <p class="card-text">Dependencies</p>
                     </div>
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            November 23rd 2020, 7:16:09 am
+                            December 1st 2020, 1:44:54 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -100,12 +100,36 @@ test.group('schema | string.optional', () => {
 		assert.equal(schema.string({ format: 'host' })('HOST', 'adonisjs.dev'), 'adonisjs.dev')
 	})
 
-	test('validate value as a url', (assert) => {
-		const fn = () => schema.string({ format: 'url' })('MAILGUN_URL', 'foo')
+	test('validate value as a url (strict defaults)', (assert) => {
+		const fn = () => schema.string({ format: 'url' })('MAILGUN_URL', 'foo.com')
 		assert.throw(fn, 'Value for environment variable "MAILGUN_URL" must be a valid URL')
+		const fnTld = () =>
+			schema.string({ format: 'url' })('MAILGUN_URL', 'https://mailgun-service:1234/v1')
+		assert.throw(fnTld, 'Value for environment variable "MAILGUN_URL" must be a valid URL')
 		assert.equal(
 			schema.string({ format: 'url' })('MAILGUN_URL', 'https://api.mailgun.net/v1'),
 			'https://api.mailgun.net/v1'
+		)
+	})
+
+	test('validate value as a url (loose options)', (assert) => {
+		assert.equal(
+			schema.string({ format: 'url', protocol: false })('MAILGUN_URL', 'foo.com'),
+			'foo.com'
+		)
+		assert.equal(
+			schema.string({ format: 'url', tld: false })(
+				'MAILGUN_URL',
+				'https://mailgun-service:1234/v1'
+			),
+			'https://mailgun-service:1234/v1'
+		)
+		assert.equal(
+			schema.string({ format: 'url', protocol: false, tld: false })(
+				'MAILGUN_URL',
+				'mailgun:1234/v1'
+			),
+			'mailgun:1234/v1'
 		)
 	})
 })


### PR DESCRIPTION
Similar to https://github.com/adonisjs/env/pull/18

BREAKING CHANGE: the validator now throws by default for URLs without a protocol.

## Proposed changes

This aims to support URLs without a top-level domain. Those are common in private networks such as corporate or Docker networks.

Note that the test with URL `"foo"` now doesn't throw anymore because by default `isURL(str)` doesn't require a protocol (such as http://) to be present.