### PR TITLE
feat(parser): allow to customize interpolation of value

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -42,13 +42,18 @@ export class Env<EnvValues extends Record<string, any>> {
    */
   static async create<Schema extends { [key: string]: ValidateFn<unknown> }>(
     appRoot: URL,
-    schema: Schema
+    schema: Schema,
+    options?: { onVariableRead?: (key: string, value: string) => string | Promise<string> }
   ): Promise<
     Env<{
       [K in keyof Schema]: ReturnType<Schema[K]>
     }>
   > {
-    const values = await new EnvProcessor(appRoot).process()
+    const processor = new EnvProcessor(appRoot, {
+      onVariableRead: options?.onVariableRead,
+    })
+
+    const values = await processor.process()
     const validator = this.rules(schema)
     return new Env(validator.validate(values))
   }

--- a/test/env.spec.ts
+++ b/test/env.spec.ts
@@ -96,4 +96,31 @@ test.group('Env', (group) => {
     assert.equal(env.get('PORT'), 3000)
     expectTypeOf(env.get('PORT')).toEqualTypeOf<number>()
   })
+
+  test('validate and process environment variables with custom hook', async ({
+    assert,
+    expectTypeOf,
+    cleanup,
+    fs,
+  }) => {
+    cleanup(() => {
+      delete process.env.PORT
+    })
+
+    await fs.create('.env', 'PORT=3000')
+    const env = await Env.create(
+      fs.baseUrl,
+      {
+        PORT: Env.schema.string(),
+      },
+      {
+        onVariableRead(_key, _value) {
+          return 'abc'
+        },
+      }
+    )
+
+    assert.equal(env.get('PORT'), 'abc')
+    expectTypeOf(env.get('PORT')).toEqualTypeOf<string>()
+  })
 })

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -32,7 +32,7 @@ test.group('Env Parser', () => {
     ].join('\n')
 
     const parser = new EnvParser(envString)
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'PORT': '3333',
@@ -66,7 +66,7 @@ test.group('Env Parser', () => {
     const envString = ['ENV_USER=romain', 'REDIS-USER=$ENV_USER'].join('\n')
     const parser = new EnvParser(envString, { ignoreProcessEnv: true })
 
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'ENV_USER': 'romain',
@@ -87,7 +87,7 @@ test.group('Env Parser', () => {
     const envString = ['ENV_USER=romain', 'REDIS-USER=$ENV_USER'].join('\n')
     const parser = new EnvParser(envString)
 
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'ENV_USER': 'virk',
@@ -108,10 +108,26 @@ test.group('Env Parser', () => {
     const envString = ['REDIS-USER=$ENV_USER'].join('\n')
     const parser = new EnvParser(envString)
 
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'REDIS-USER': 'virk',
+    })
+  })
+
+  test('use custom hook to interpolate values', async ({ assert }) => {
+    const envString = ['PORT=3333', 'HOST=127.0.0.1'].join('\n')
+
+    const parser = new EnvParser(envString, {
+      onVariableRead(_key, _value) {
+        return '1'
+      },
+    })
+    const parsed = await parser.parse()
+
+    assert.deepEqual(parsed, {
+      PORT: '1',
+      HOST: '1',
     })
   })
 })

--- a/test/processor.spec.ts
+++ b/test/processor.spec.ts
@@ -33,6 +33,32 @@ test.group('Env processor', () => {
     assert.deepEqual(values, { HOST: 'localhost', PORT: '3000' })
   })
 
+  test('process .env file with custom hook', async ({ assert, cleanup, fs }) => {
+    cleanup(() => {
+      delete process.env.PORT
+      delete process.env.HOST
+    })
+
+    await fs.create(
+      '.env',
+      `
+    HOST=localhost
+    PORT=3000
+    `
+    )
+
+    const app = new EnvProcessor(fs.baseUrl, {
+      onVariableRead(_key, _value) {
+        return '1'
+      },
+    })
+
+    const values = await app.process()
+    assert.equal(process.env.HOST, '1')
+    assert.equal(process.env.PORT, '1')
+    assert.deepEqual(values, { HOST: '1', PORT: '1' })
+  })
+
   test('process .env.local and .env files', async ({ assert, cleanup, fs }) => {
     cleanup(() => {
       delete process.env.PORT


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds a way to set up a custom hook, helping to interpolate the value of your env.

It can be useful in multiple scenarios.

1. To manage your secrets, you may use a Secrets Vault like `Docker Secret` or `HashiCorp Vault`. Doing so it will generate a path for your secret and won't give you any value directly. You can write a custom logic to read the file content.
```.env
DB_PASSWORD=file:/run/secrets/db_password
````

2. You may encrypt your secrets. You will be able to decrypt them on the fly.
```.env
APP_KEY=encrypted:ksadskjadsjkdasjkdsjdjaskjkdjkasdkj
```

In user-land, they will be able to pass an option to their `Env.create()` call.

```ts
Env.create(new URL('../', import.meta.url), {
  ....
}, {
  async onVariableRead(key, value) {
    if (value.startWidth('file:') {
      // read from file...
    }
    
    return value
  }
})
```

I am unsure if passing the `key` to the custom hook is useful. Also, if we do, I don't know if the `value` should be the first argument since people will often use it and disregard the env key.