### PR TITLE
feat(parser): allow to add identifiers

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -10,6 +10,7 @@
 import { schema as envSchema, type ValidateFn } from '@poppinss/validator-lite'
 import { EnvValidator } from './validator.js'
 import { EnvProcessor } from './processor.js'
+import { EnvParser } from './parser.js'
 
 /**
  * A wrapper over "process.env" with types information.
@@ -51,6 +52,21 @@ export class Env<EnvValues extends Record<string, any>> {
     const values = await new EnvProcessor(appRoot).process()
     const validator = this.rules(schema)
     return new Env(validator.validate(values))
+  }
+
+  /**
+   * Define an identifier for any environment value. The callback is invoked
+   * when the value match the identifier to modify its interpolation.
+   */
+  static identifier(name: string, callback: (value: string) => Promise<string> | string): void {
+    EnvParser.identifier(name, callback)
+  }
+
+  /**
+   * Remove an identifier
+   */
+  static removeIdentifier(name: string): void {
+    EnvParser.removeIdentifier(name)
   }
 
   /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { Exception } from '@poppinss/utils'
+import { createError, Exception } from '@poppinss/utils'
 
 /**
  * Exception raised when one or more env variables
@@ -18,3 +18,9 @@ export const E_INVALID_ENV_VARIABLES = class EnvValidationException extends Exce
   static code = 'E_INVALID_ENV_VARIABLES'
   help: string = ''
 }
+
+export const E_IDENTIFIER_ALREADY_DEFINED = createError<[string]>(
+  'The identifier "%s" is already defined',
+  'E_IDENTIFIER_ALREADY_DEFINED',
+  500
+)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -212,6 +212,12 @@ export class EnvParser {
 
             continue $keyLoop
           }
+
+          if (value.startsWith(`${identifier}\\:`)) {
+            result[key] = identifier + value.substring(identifier.length + 1)
+
+            continue $keyLoop
+          }
         }
 
         result[key] = value

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -205,7 +205,7 @@ export class EnvParser {
 
       if (value.includes(':')) {
         for (const identifier of identifiers) {
-          if (value.startsWith(identifier)) {
+          if (value.startsWith(`${identifier}:`)) {
             result[key] = await EnvParser.#identifiers[identifier](
               value.substring(identifier.length + 1)
             )

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -27,7 +27,7 @@ export class EnvProcessor {
   /**
    * Parse env variables from raw contents
    */
-  #processContents(envContents: string, store: Record<string, any>) {
+  async #processContents(envContents: string, store: Record<string, any>) {
     /**
      * Collected env variables
      */
@@ -35,7 +35,9 @@ export class EnvProcessor {
       return store
     }
 
-    const values = new EnvParser(envContents).parse()
+    const parser = new EnvParser(envContents)
+    const values = await parser.parse()
+
     Object.keys(values).forEach((key) => {
       let value = process.env[key]
 
@@ -70,7 +72,7 @@ export class EnvProcessor {
      * Collected env variables
      */
     const envValues: Record<string, any> = {}
-    envFiles.forEach(({ contents }) => this.#processContents(contents, envValues))
+    await Promise.all(envFiles.map(({ contents }) => this.#processContents(contents, envValues)))
     return envValues
   }
 

--- a/tests/env.spec.ts
+++ b/tests/env.spec.ts
@@ -16,6 +16,25 @@ test.group('Env', (group) => {
     delete process.env.ENV_HOST
   })
 
+  test('define identifier', async ({ assert, cleanup, fs }) => {
+    assert.plan(1)
+
+    cleanup(() => {
+      Env.removeIdentifier('file')
+    })
+
+    Env.identifier('file', (_value: string) => {
+      assert.isTrue(true)
+
+      return '3000'
+    })
+
+    await fs.create('.env', 'PORT=file:romain')
+    await Env.create(fs.baseUrl, {
+      PORT: Env.schema.number(),
+    })
+  })
+
   test('read values from process.env', ({ assert, expectTypeOf, cleanup }) => {
     process.env.PORT = '4000'
     cleanup(() => {

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -72,6 +72,29 @@ test.group('Env Parser', () => {
     })
   })
 
+  test('identifier is used only when complete value is matched', async ({
+    assert,
+    cleanup,
+    expectTypeOf,
+  }) => {
+    cleanup(() => {
+      EnvParser.removeIdentifier('file')
+    })
+
+    EnvParser.identifier('file', (_value: string) => {
+      return '3000'
+    })
+
+    const envString = ['ENV_USER=file_romain:romain'].join('\n')
+    const parser = new EnvParser(envString)
+    const parsed = await parser.parse()
+
+    expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
+    assert.deepEqual(parsed, {
+      ENV_USER: 'file_romain:romain',
+    })
+  })
+
   test('throw when identifier is already defined', async ({ assert, cleanup }) => {
     cleanup(() => {
       EnvParser.removeIdentifier('file')

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -32,7 +32,7 @@ test.group('Env Parser', () => {
     ].join('\n')
 
     const parser = new EnvParser(envString)
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'PORT': '3333',
@@ -53,6 +53,38 @@ test.group('Env Parser', () => {
     })
   })
 
+  test('define identifier', async ({ assert, cleanup, expectTypeOf }) => {
+    cleanup(() => {
+      EnvParser.removeIdentifier('file')
+    })
+
+    EnvParser.identifier('file', (_value: string) => {
+      return '3000'
+    })
+
+    const envString = ['ENV_USER=file:romain'].join('\n')
+    const parser = new EnvParser(envString)
+    const parsed = await parser.parse()
+
+    expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
+    assert.deepEqual(parsed, {
+      ENV_USER: '3000',
+    })
+  })
+
+  test('throw when identifier is already defined', async ({ assert, cleanup }) => {
+    cleanup(() => {
+      EnvParser.removeIdentifier('file')
+    })
+
+    EnvParser.identifier('file', (_value: string) => 'test')
+
+    assert.throws(
+      () => EnvParser.identifier('file', (_value: string) => 'test'),
+      'The identifier "file" is already defined'
+    )
+  })
+
   test('give preference to the parsed values when interpolating values', async ({
     assert,
     expectTypeOf,
@@ -66,7 +98,7 @@ test.group('Env Parser', () => {
     const envString = ['ENV_USER=romain', 'REDIS-USER=$ENV_USER'].join('\n')
     const parser = new EnvParser(envString, { ignoreProcessEnv: true })
 
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'ENV_USER': 'romain',
@@ -87,7 +119,7 @@ test.group('Env Parser', () => {
     const envString = ['ENV_USER=romain', 'REDIS-USER=$ENV_USER'].join('\n')
     const parser = new EnvParser(envString)
 
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'ENV_USER': 'virk',
@@ -108,7 +140,7 @@ test.group('Env Parser', () => {
     const envString = ['REDIS-USER=$ENV_USER'].join('\n')
     const parser = new EnvParser(envString)
 
-    const parsed = parser.parse()
+    const parsed = await parser.parse()
     expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
     assert.deepEqual(parsed, {
       'REDIS-USER': 'virk',

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -95,6 +95,25 @@ test.group('Env Parser', () => {
     })
   })
 
+  test('allows to escape the identifier', async ({ assert, cleanup, expectTypeOf }) => {
+    cleanup(() => {
+      EnvParser.removeIdentifier('file')
+    })
+
+    EnvParser.identifier('file', (_value: string) => {
+      return '3000'
+    })
+
+    const envString = ['ENV_USER=file\\:///root/app/user.js'].join('\n')
+    const parser = new EnvParser(envString)
+    const parsed = await parser.parse()
+
+    expectTypeOf(parsed).toEqualTypeOf<DotenvParseOutput>()
+    assert.deepEqual(parsed, {
+      ENV_USER: 'file:///root/app/user.js',
+    })
+  })
+
   test('throw when identifier is already defined', async ({ assert, cleanup }) => {
     cleanup(() => {
       EnvParser.removeIdentifier('file')


### PR DESCRIPTION
Hey there! 👋🏻

This PR is the continuation of https://github.com/adonisjs/env/pull/35.
It adds a way to set up an identifier for an environment variable, helping to interpolate the value of your env.

It can be useful in multiple scenarios.

1. To manage your secrets, you may use a Secrets Vault like `Docker Secret` or `HashiCorp Vault`. Doing so it will generate a path for your secret and won't give you any value directly. You can write a custom logic to read the file content.
```.env
DB_PASSWORD=file:/run/secrets/db_password
````

2. You may encrypt your secrets. You will be able to decrypt them on the fly.
```.env
APP_KEY=encrypted:ksadskjadsjkdasjkdsjdjaskjkdjkasdkj
```

```ts
Env.identifier('file', (value: string) => {
  // ...
})

Env.create(new URL('../', import.meta.url), {
  ....
})
```