### PR TITLE
feat: EnvEditor.add with empty value for .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ editor.add('HOST', 'localhost')
 await editor.save()
 ```
 
+You can also insert an empty value for the `.env.example` file by setting the last argument to `true`.
+
+```ts
+editor.add('SECRET_VARIABLE', 'secret-value', true)
+```
+
+This will add the following line to the `.env.example` file.
+
+```env
+SECRET_VARIABLE=
+```
+
 ## Known Exceptions
 
 ### E_INVALID_ENV_VARIABLES

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -57,8 +57,8 @@ export class EnvEditor {
 
   /**
    * Add key-value pair to the dot-env files.
-   * If `withEmptyExampleValue` is true, then only the key is added to the
-   * `.env.example` file.
+   * If `withEmptyExampleValue` is true then the key will be added with an empty value
+   * to the `.env.example` file.
    */
   add(key: string, value: string | number | boolean, withEmptyExampleValue = false) {
     this.#files.forEach((file) => {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -57,13 +57,20 @@ export class EnvEditor {
 
   /**
    * Add key-value pair to the dot-env files.
+   * If `withEmptyExampleValue` is true, then only the key is added to the
+   * `.env.example` file.
    */
-  add(key: string, value: string | number | boolean) {
+  add(key: string, value: string | number | boolean, withEmptyExampleValue = false) {
     this.#files.forEach((file) => {
       let entryIndex = file.contents.findIndex((line) => line.startsWith(`${key}=`))
 
       entryIndex = entryIndex === -1 ? file.contents.length : entryIndex
-      lodash.set(file.contents, entryIndex, `${key}=${String(value)}`)
+
+      if (withEmptyExampleValue && file.path.endsWith('.env.example')) {
+        lodash.set(file.contents, entryIndex, `${key}=`)
+      } else {
+        lodash.set(file.contents, entryIndex, `${key}=${value}`)
+      }
     })
   }
 

--- a/tests/editor.spec.ts
+++ b/tests/editor.spec.ts
@@ -129,4 +129,23 @@ test.group('Env editor | modify', () => {
     await assert.fileEquals('.env', ['PORT=3000', '', 'HOST=127.0.0.1'].join('\n'))
     await assert.fileEquals('.env.example', ['', 'PORT=3000', 'HOST=127.0.0.1'].join('\n'))
   })
+
+  test('add key with empty example value', async ({ assert, fs }) => {
+    await fs.create('.env', '')
+    await fs.create('.env.example', '')
+
+    const editor = await EnvEditor.create(fs.baseUrl)
+    editor.add('PORT', 3000, true)
+
+    assert.deepEqual(editor.toJSON(), [
+      {
+        path: join(fs.basePath, '.env'),
+        contents: ['', 'PORT=3000'],
+      },
+      {
+        path: join(fs.basePath, '.env.example'),
+        contents: ['', 'PORT='],
+      },
+    ])
+  })
 })


### PR DESCRIPTION
As explained here: https://github.com/adonisjs/core/pull/4533

We add a third argument `withEmptyExampleValue` to the `EnvEditor` `add` method which allows to insert a empty value in the `.env.example` file

```ts
const editor = await EnvEditor.create(fs.baseUrl)
editor.add('PORT', 3000, true)
```

This will result in `PORT=3000` in the `.env` file, but with `PORT=` in the `.env.example` file.