### PR TITLE
Fix incorrectly bypassing default value on `get()` caused by undefined

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -145,6 +145,11 @@ export class Env<EnvValues extends Record<string, any>> {
   set<K extends keyof EnvValues>(key: K, value: EnvValues[K]): void
   set(key: string, value: string): void
   set(key: string | keyof EnvValues, value: any): void {
+    if (value === undefined) {
+      delete this.#values[key]
+      delete process.env[key as string]
+      return
+    }
     this.#values[key] = value
     process.env[key as string] = value
   }

--- a/tests/env.spec.ts
+++ b/tests/env.spec.ts
@@ -74,6 +74,18 @@ test.group('Env', (group) => {
     assert.equal(port, 3000)
   })
 
+  test('return default value when env is re-set to undefined', ({ assert, cleanup }) => {
+    const env = new Env<{ VALUE?: string }>({ VALUE: undefined })
+    env.set('VALUE', 'new value')
+
+    cleanup(() => {
+      delete process.env.VALUE
+    })
+    assert.equal(env.get('VALUE', 'DEFAULT'), 'new value')
+    env.set('VALUE', undefined)
+    assert.equal(env.get('VALUE', 'DEFAULT'), 'DEFAULT')
+  })
+
   test('update env value', ({ assert, cleanup }) => {
     cleanup(() => {
       delete process.env.PORT


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/adonisjs/env/issues/42

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves an edge case #42.

When an env value was undefined and set to a value, then manually set to `undefined` again, `env.get('VAR', 'DEFAULT')` 
will not return the correct default value.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
