### PR TITLE
feat: add base64 identifier to EnvParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ console.log(await envParser.parse()) // { DB_PASSWORD: 'Value from file /run/sec
 
 This can be useful when you are using secrets manager like `Docker Secret`, `HashiCorp Vault`, `Google Secrets Manager` and others to manage your secrets.
 
+The parser also includes a built-in `base64` identifier. It decodes values using a Node.js `Buffer`.
+
+```env
+APP_KEY=base64:YWRvbmlzanMtcnVsZXM=
+```
+
 ## Validating environment variables
 Once you have the parsed objects, you can optionally validate them against a pre-defined schema. We recommend validation for the following reasons.
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -74,6 +74,10 @@ export class EnvParser {
    * Static collection of registered identifiers with their callbacks
    */
   static #identifiers: Record<string, EnvIdentifierCallback> = {
+    base64(value) {
+      return Buffer.from(value, 'base64').toString('utf-8')
+    },
+
     async file(value, key, appRoot) {
       const filePath = new URL(value, appRoot)
       try {

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -225,6 +225,17 @@ test.group('Env Parser', () => {
     })
   })
 
+  test('decode value using the base64 identifier', async ({ assert, fs, expectTypeOf }) => {
+    const envString = ['APP_KEY=base64:YWRvbmlzanMtcnVsZXM='].join('\n')
+    const parser = new EnvParser(envString, fs.baseUrl)
+    const parsed = await parser.parse()
+
+    expectTypeOf(parsed).toEqualTypeOf<NodeJS.Dict<string>>()
+    assert.deepEqual(parsed, {
+      APP_KEY: 'adonisjs-rules',
+    })
+  })
+
   test('throw error when file is missing', async ({ fs, expectTypeOf }) => {
     const envString = ['PACKAGE_FILE=file:./package.json'].join('\n')
     const parser = new EnvParser(envString, fs.baseUrl)


### PR DESCRIPTION
### 🔗 Linked issue

No existing issue

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The objective is to retrieve a value that has been given in base64.
Using the key `APP_KEY=base64:YWRvbmlzanMtcnVsZXM=`, we can directly retrieve the value `adonisjs-rules`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
